### PR TITLE
Added a border search feature

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -358,6 +358,10 @@
 	"updatePageTitleInstall": {
 		"message": "Page Ruler Installed",
 		"description": "Page title for the install page"
-	}
+	},
 
+	"toolbarBorderSearch": {
+		"message":	"Border Search",
+		"description": "Label for the show border search toggle in the toolbar"
+	}
 }

--- a/src/css/content.less
+++ b/src/css/content.less
@@ -261,6 +261,13 @@ input {
 		}
 	}
 
+	#page-ruler-toolbar-borderSearch-container {
+		padding-top:	2px !important;
+		> label {
+			top: -8px !important;
+		}
+	}
+
 	#page-ruler-toolbar-container {
 		height:				@toolbar-height !important;
 		display:			table-cell !important;
@@ -379,8 +386,7 @@ input {
 		width:		100% !important;
 		height:		100% !important;
 		cursor:		move !important;
-		overflow:	hidden !important;
-
+		
 		.page-ruler-corner {
 			position:		absolute !important;
 			width:			16px !important;
@@ -449,6 +455,10 @@ input {
 			cursor:			sw-resize !important;
 		}
 
+		.page-ruler-bordersearch {
+			cursor: pointer !important;
+		}
+
 		.page-ruler-bottom-right {
 			bottom:			0px !important;
 			right:			0px !important;
@@ -457,6 +467,53 @@ input {
 			cursor:			se-resize !important;
 		}
 
+		.page-ruler-bordersearch-ud-left-top {
+			top:		-16px !important;
+			left:		0px !important;
+			content: 	url('images/arrow-up.png');
+		}
+
+		.page-ruler-bordersearch-ud-right-top {
+			top:		-16px !important;
+			right:		0px !important;
+			content: 	url('images/arrow-up.png');
+		}
+
+		.page-ruler-bordersearch-lr-left-top {
+			top:		0px !important;
+			left:		-16px !important;
+			content: 	url('images/arrow-left.png');
+		}
+
+		.page-ruler-bordersearch-lr-left-bottom {
+			bottom:		0px !important;
+			left:		-16px !important;
+			content: 	url('images/arrow-left.png');
+		}
+
+		.page-ruler-bordersearch-lr-right-top {
+			top:		0px !important;
+			right:		-16px !important;
+			content: 	url('images/arrow-right.png');
+		}
+
+		.page-ruler-bordersearch-lr-right-bottom {
+			bottom:		0px !important;
+			right:		-16px !important;
+			content: 	url('images/arrow-right.png');
+		}
+
+		.page-ruler-bordersearch-ud-left-bottom {
+			bottom:		-16px !important;
+			left:		0px !important;
+			content: 	url('images/arrow-down.png');
+		}
+
+		.page-ruler-bordersearch-ud-right-bottom {
+			bottom:		-16px !important;
+			right:		0px !important;
+			content: 	url('images/arrow-down.png');
+		}
 	}
 
 	&.page-ruler-tracking {
@@ -595,6 +652,15 @@ input {
 		}
 	}
 	#page-ruler-toolbar-guides-toggle {
+		margin-top: 3px !important;
+		transform: scale(0.8) !important;
+	}
+	#page-ruler-toolbar-borderSearch-container {
+		> label {
+			display: none !important;
+		}
+	}
+	#page-ruler-toolbar-borderSearch-toggle {
 		margin-top: 3px !important;
 		transform: scale(0.8) !important;
 	}

--- a/src/js/content/pageruler/el/BorderSearch.js
+++ b/src/js/content/pageruler/el/BorderSearch.js
@@ -1,0 +1,61 @@
+/**
+ * Resize element
+ */
+
+(function(pr) {
+
+pr.el.BorderSearch = pr.cls(
+
+	/**
+	 * Class constructor
+	 * @param {PageRuler.el.Ruler} ruler	The ruler object
+	 * @param {string} positionDir			Direction of the search
+	 * @param {string} leftOrRight			Position on left or right side
+	 * @param {string} topOrBottom			Position on top or bottom
+	 * @param {string} cls					Class
+	 */
+	function(ruler, positionDir, leftOrRight, topOrBottom, cls) {
+		var id = 'bordersearch-' + positionDir + '-' + leftOrRight + '-' + topOrBottom;
+		// get positions from id
+		// set attributes
+		var attrs = {
+			'id':	 id,
+			'class': [cls, id]
+		};
+		
+		// create dom element
+		this.dom = pr.El.createEl('div', attrs);
+
+		// add mousedown listener - this will start the search
+		pr.El.registerListener(this.dom, 'click', function(e) {
+
+			// we don't want to interact with any other elements
+			e.stopPropagation();
+			e.preventDefault();
+				
+			// Search for a border
+			ruler.borderSearch(positionDir, leftOrRight, topOrBottom);
+		});
+	},
+	{
+
+		/**
+		 * The dom element
+		 * @type {HTMLElement}
+		 */
+		dom:	null,
+
+		/**
+		 * Sets the border color of the ColorJump element
+		 * @param {string} hex
+		 */
+		setColor: function(hex) {
+
+			this.dom.style.setProperty('border-color', hex, 'important');
+
+		}
+	}
+
+);
+
+})(__PageRuler);

--- a/src/js/content/pageruler/el/Toolbar.js
+++ b/src/js/content/pageruler/el/Toolbar.js
@@ -46,6 +46,7 @@ pr.el.Toolbar = pr.cls(
 		var positionContainer		= this.generatePositionContainer();
 		var colorContainer			= this.generateColorContainer();
 		var guidesContainer			= this.generateGuidesContainer();
+		var borderSearchContainer	= this.generateBorderSearchContainer();
 
 		// add contents to container
 		pr.El.appendEl(container, [
@@ -56,7 +57,8 @@ pr.el.Toolbar = pr.cls(
 			dimensionsContainer,
 			positionContainer,
 			colorContainer,
-			guidesContainer
+			guidesContainer,
+			borderSearchContainer
 		]);
 
 		this.elementToolbar = new pr.el.ElementToolbar(this);
@@ -106,6 +108,21 @@ pr.el.Toolbar = pr.cls(
 			}
 		);
 
+		// set the border search visiblity
+		chrome.runtime.sendMessage(
+			{
+				action:	'getBorderSearch'
+			},
+			function(visible) {
+				// set border search visibility
+				pr.elements.ruler.setBorderSearchVisibility(visible, false);
+
+				// if not visible then also change the toggle
+				if (!visible) {
+					_this.els.borderSearch.checked = false;
+				}
+			}
+		);
 	},
 	{
 
@@ -603,6 +620,86 @@ pr.el.Toolbar = pr.cls(
 			]);
 
 			return guidesContainer;
+
+		},
+
+		generateBorderSearchContainer: function() {
+
+			// create container
+			var borderSearchContainer = pr.El.createEl('div', {
+				'id':	'toolbar-borderSearch-container',
+				'cls':	'container'
+			});
+
+			// create label
+			var label = pr.El.createEl('label', {
+				'id':	'toolbar-borderSearch-label',
+				'for':	'toolbar-borderSearch-input'
+			}, {}, pr.Util.locale('toolbarBorderSearch') + ':');
+
+			var lang = (navigator.language || '').split('-')[0];
+			if (!!lang) {
+				lang = 'lang_' + lang;
+			}
+
+			// create toggle element
+			var toggle = pr.El.createEl('div', {
+				'id':	'toolbar-borderSearch-toggle',
+				'cls':	'checkbox-toggle ' + lang
+			});
+
+			// create checkbox element
+			var input = pr.El.createEl('input', {
+				'id':		'toolbar-borderSearch-input',
+				'type':		'checkbox',
+				'checked':	true
+			}, {
+				'change': function(e) {
+					console.log('saving setBorderSearchVisibility');
+					pr.elements.ruler.setBorderSearchVisibility(this.checked, true);
+				}
+			});
+
+			// set reference to checkbox
+			this.els.borderSearch = input;
+
+			// create toggle label
+			var toggleLabel = pr.El.createEl('label', {
+				'id':	'toolbar-borderSearch-toggle-label',
+				'for':	'toolbar-borderSearch-input'
+			});
+
+			// create label inner
+			var labelInner = pr.El.createEl('div', {
+				'id':		'toolbar-borderSearch-label-inner',
+				'class':	'inner'
+			});
+
+			// create label switch
+			var labelSwitch = pr.El.createEl('div', {
+				'id':		'toolbar-borderSearch-label-switch',
+				'class':	'switch ' + lang
+			});
+
+			// add label contents
+			pr.El.appendEl(toggleLabel, [
+				labelInner,
+				labelSwitch
+			]);
+
+			// add toggle contents
+			pr.El.appendEl(toggle, [
+				input,
+				toggleLabel
+			]);
+
+			// add container contents
+			pr.El.appendEl(borderSearchContainer, [
+				label,
+				toggle
+			]);
+
+			return borderSearchContainer;
 
 		},
 


### PR DESCRIPTION
This is a feature I've been using in a local version of page-ruler for a while. Thought it may make a nice addition to the tool. Turning on "border search" adds some arrows to the ruler that you can click to make the ruler expand in that direction until it detects a border. It considers a border a change in color above a threshold. There are 8 arrows (2 facing up/down, left/right in each of the 4 corners). It is handy if you are measuring parts of regions, across regions, or images.

On the code side it uses Chrome's captureVisibleTab function to take a screenshot so it can look at the pixel colors. There is some devicePixelRatio math to convert from the css pixels of the ruler to pixels on the screenshot.  For the arrows I just reused the arrow png's you already had in the project.